### PR TITLE
refactor: DeviceLanguage enum BCP 47 표준 코드 교체 + 히스토리 결과 UI 개선

### DIFF
--- a/Component/componentbattery.cpp
+++ b/Component/componentbattery.cpp
@@ -152,27 +152,27 @@ int ComponentBattery::getFilteredBattery() const
 // Improvement 4: Hysteresis icon selection (±3%)
 int ComponentBattery::selectIconLevel(int batteryValue)
 {
-    // Thresholds: 90/60/30/10 for descending, +3 for ascending
+    // Thresholds: 80/50/25/10 for descending, +3 for ascending
     if(nCurrentIconLevel == 100)
     {
-        if(batteryValue < 90) return 75;
+        if(batteryValue < 80) return 75;
         return 100;
     }
     else if(nCurrentIconLevel == 75)
     {
-        if(batteryValue >= 93) return 100;
-        if(batteryValue < 60) return 50;
+        if(batteryValue >= 83) return 100;
+        if(batteryValue < 50) return 50;
         return 75;
     }
     else if(nCurrentIconLevel == 50)
     {
-        if(batteryValue >= 63) return 75;
-        if(batteryValue < 30) return 15;
+        if(batteryValue >= 53) return 75;
+        if(batteryValue < 25) return 15;
         return 50;
     }
     else if(nCurrentIconLevel == 15)
     {
-        if(batteryValue >= 33) return 50;
+        if(batteryValue >= 28) return 50;
         if(batteryValue < 10) return 5;
         return 15;
     }

--- a/Component/componentbluetooth.cpp
+++ b/Component/componentbluetooth.cpp
@@ -85,9 +85,6 @@ void ComponentBluetooth::update()
 
 void ComponentBluetooth::mousePressEvent(QMouseEvent* ev)
 {
-    if(instance.currentPage==PAGE_HISTORY_RESULT)
-        return;
-
     if(instance.touchCheck(this->rect(),ev))
     {
         //qDebug()<<"comBluetooth";

--- a/Component/componenthome.cpp
+++ b/Component/componenthome.cpp
@@ -38,9 +38,6 @@ void ComponentHome::mousePressEvent(QMouseEvent *ev)
         return;
     }
 
-    if(instance.currentPage==PAGE_HISTORY_RESULT)
-        return;
-
     if(instance.touchCheck(this->rect(),ev))
     {
         emit singalShowPageNum(PAGE_HOME);

--- a/Component/componentmenu.cpp
+++ b/Component/componentmenu.cpp
@@ -25,9 +25,6 @@ void ComponentMenu::mousePressEvent(QMouseEvent* ev)
     if(!getIsEnable())
         return;
 
-    if(instance.currentPage==PAGE_HISTORY_RESULT)
-        return;
-
     if(instance.touchCheck(this->rect(),ev))
     {
         instance.isComMenuCheck = true;

--- a/Page/pageresult.cpp
+++ b/Page/pageresult.cpp
@@ -182,15 +182,15 @@ void PageResult::setValueUI()
 
     switch (instance.getDeviceLanguage())
     {
-    case KR:
+    case ko:
         strLabelText += "<span style='font-weight:bold; "+strTextGlucoseValueColor+"'>"+textResource.getText(PAGE_RESULT,"indexResult").at(nBloodSugarIndex)+" </span>"
                 +"<span style='color: #808080; '>"+textResource.getText(PAGE_RESULT,"indexResultSub").at(0)+"</span>";
         break;
-    case EN:
-    case JP:
-    case SC:
-    case TC:
-    case ES:
+    case en:
+    case ja:
+    case zh_CN:
+    case zh_TW:
+    case es:
         strLabelText += "<p style='font-weight:bold; "+strTextGlucoseValueColor+" line-height: 0.5; font-size: 30px;'>"+textResource.getText(PAGE_RESULT,"indexResult").at(nBloodSugarIndex)+"</p>"
                 +"<p style='color: #808080; font-size: 30px;'>"+textResource.getText(PAGE_RESULT,"indexResultSub").at(nBloodSugarIndex)+"</p>";
     case LAN_MAX:

--- a/Page/pageselect.cpp
+++ b/Page/pageselect.cpp
@@ -154,14 +154,14 @@ void PageSelect::updateStatus()
 
         switch (instance.getDeviceLanguage())
         {
-        case KR:
+        case ko:
             nResultSubIndex = 0;
             break;
-        case EN:
-        case JP:
-        case SC:
-        case TC:
-        case ES:
+        case en:
+        case ja:
+        case zh_CN:
+        case zh_TW:
+        case es:
             nResultSubIndex = bloodSugarIndex;
         case LAN_MAX:
             break;

--- a/Page/pagethreshold.cpp
+++ b/Page/pagethreshold.cpp
@@ -93,10 +93,10 @@ void PageThreshold::update()
 
     switch (instance.getDeviceLanguage())
     {
-    case KR:
-    case JP:
-    case SC:
-    case TC:
+    case ko:
+    case ja:
+    case zh_CN:
+    case zh_TW:
         labelValueLow->setGeometry(370,138,90,59);
         labelValueLow->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
         labelValueHigh->setGeometry(370,257,90,59);
@@ -107,8 +107,8 @@ void PageThreshold::update()
         labelValueRangeHigh->setGeometry(467,274,45,38);
         labelValueRangeHigh->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
         break;
-    case EN:
-    case ES:
+    case en:
+    case es:
         labelValueLow->setGeometry(425,138,90,59);
         labelValueLow->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
         labelValueHigh->setGeometry(425,257,90,59);

--- a/Page/pagetrans.cpp
+++ b/Page/pagetrans.cpp
@@ -43,12 +43,12 @@ void PageTrans::init()
 
 void PageTrans::fontMapping()
 {
-    fontMap[KR] = textResource.getFont(PAGE_TRANS,"fontSuit");
-    fontMap[EN] = textResource.getFont(PAGE_TRANS,"fontSuit");
-    fontMap[JP] = textResource.getFont(PAGE_TRANS,"fontJP");
-    fontMap[SC] = textResource.getFont(PAGE_TRANS,"fontSC");
-    fontMap[TC] = textResource.getFont(PAGE_TRANS,"fontTC");
-    fontMap[ES] = textResource.getFont(PAGE_TRANS,"fontSuit");
+    fontMap[ko] = textResource.getFont(PAGE_TRANS,"fontSuit");
+    fontMap[en] = textResource.getFont(PAGE_TRANS,"fontSuit");
+    fontMap[ja] = textResource.getFont(PAGE_TRANS,"fontJP");
+    fontMap[zh_CN] = textResource.getFont(PAGE_TRANS,"fontSC");
+    fontMap[zh_TW] = textResource.getFont(PAGE_TRANS,"fontTC");
+    fontMap[es] = textResource.getFont(PAGE_TRANS,"fontSuit");
 }
 
 void PageTrans::update()

--- a/Page/pagetrans.h
+++ b/Page/pagetrans.h
@@ -22,7 +22,7 @@ public:
     QLabel *labelButtonGradientTop;
     QLabel *labelButtonGradientDown;
 
-    DeviceLanguage deviceLan = KR;
+    DeviceLanguage deviceLan = ko;
     CustomButtonOK *customButtonOK;
     CustomButtonCancel *customButtonCancel;
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -200,6 +200,7 @@ void MainWindow::init()
 
     pageHistoryResult = new PageHistoryResult(this);
     stackedWidget->addWidget(pageHistoryResult);
+    listComHiddenPageIndex.append(stackedWidget->indexOf(pageHistoryResult));
     qDebug()<<"====================== PAGE_HISTORY_RESULT";
 
     pageDebug = new PageDebug(this);
@@ -498,6 +499,8 @@ void MainWindow::currentPageChanged(int index)
     if(listComHiddenPageIndex.contains(index))
     {
         HideComponents();
+        if(index == stackedWidget->indexOf(pageHistoryResult))
+            comClock->pageShow();
     }
     else
     {

--- a/singleton.cpp
+++ b/singleton.cpp
@@ -2,12 +2,12 @@
 
 // 정적 멤버 초기화
 const QHash<unsigned int, QPair<QString, DeviceLanguage>> Singleton::hashLanguage = {
-    { static_cast<unsigned int>(DeviceLanguage::KR), { "/KR", DeviceLanguage::KR } },
-    { static_cast<unsigned int>(DeviceLanguage::EN), { "/EN", DeviceLanguage::EN } },
-    { static_cast<unsigned int>(DeviceLanguage::JP), { "/JP", DeviceLanguage::JP } },
-    { static_cast<unsigned int>(DeviceLanguage::SC), { "/SC", DeviceLanguage::SC } },
-    { static_cast<unsigned int>(DeviceLanguage::TC), { "/TC", DeviceLanguage::TC } },
-    { static_cast<unsigned int>(DeviceLanguage::ES), { "/ES", DeviceLanguage::ES } },
+    { static_cast<unsigned int>(DeviceLanguage::ko), { "/KR", DeviceLanguage::ko } },
+    { static_cast<unsigned int>(DeviceLanguage::en), { "/EN", DeviceLanguage::en } },
+    { static_cast<unsigned int>(DeviceLanguage::ja), { "/JP", DeviceLanguage::ja } },
+    { static_cast<unsigned int>(DeviceLanguage::zh_CN), { "/SC", DeviceLanguage::zh_CN } },
+    { static_cast<unsigned int>(DeviceLanguage::zh_TW), { "/TC", DeviceLanguage::zh_TW } },
+    { static_cast<unsigned int>(DeviceLanguage::es), { "/ES", DeviceLanguage::es } },
 };
 
 void Singleton::init()
@@ -17,7 +17,7 @@ void Singleton::init()
     updateSysUserInfo();
 #else
 
-    langData.used = KR;
+    langData.used = ko;
 
     thresholdLow = 79;
     thresholdHigh = 250;
@@ -251,18 +251,18 @@ void Singleton::setDeviceLanguage(unsigned int nLanguage)
 
         switch (nLanguage)
         {
-        case KR:
-        case EN:
-        case ES:
+        case ko:
+        case en:
+        case es:
             QApplication::setFont(fontSuit);
             break;
-        case JP:
+        case ja:
             QApplication::setFont(fontJP);
             break;
-        case SC:
+        case zh_CN:
             QApplication::setFont(fontSC);
             break;
-        case TC:
+        case zh_TW:
             QApplication::setFont(fontTC);
             break;
         }

--- a/singleton.h
+++ b/singleton.h
@@ -18,12 +18,12 @@ Q_ENUMS(DeviceColor)
 
 typedef enum
 {
-    KR = 0,
-    EN,
-    JP,
-    SC,
-    TC,
-    ES,
+    ko = 0,
+    en,
+    ja,
+    zh_CN,
+    zh_TW,
+    es,
     LAN_MAX
 } DeviceLanguage;
 

--- a/textresource.cpp
+++ b/textresource.cpp
@@ -17,7 +17,7 @@ void TextResource::init()
 
     //KR
     //CUSTOM_BUTTON
-    DeviceLanguage Lan = KR;
+    DeviceLanguage Lan = ko;
     nTextSize = 36;
     QString currentFont = instance.fontSuit;
 
@@ -1080,7 +1080,7 @@ void TextResource::init()
 
     //====================================================================================================================================
     //EN
-    Lan = EN;
+    Lan = en;
     nTextSize = 30;
     currentFont = instance.fontSuit;
 
@@ -2152,7 +2152,7 @@ void TextResource::init()
 
     //=====================================================================================================================================
     //JP
-    Lan = JP;
+    Lan = ja;
     nTextSize = 30;
     currentFont = instance.fontJP;
 
@@ -3253,7 +3253,7 @@ void TextResource::init()
 
     //=====================================================================================================================================
     //SC
-    Lan = SC;
+    Lan = zh_CN;
     nTextSize = 36;
     currentFont = instance.fontSC;
 
@@ -4353,7 +4353,7 @@ void TextResource::init()
 
     //=====================================================================================================================================
     //TC
-    Lan = TC;
+    Lan = zh_TW;
     nTextSize = 36;
     currentFont = instance.fontTC;
 
@@ -5451,7 +5451,7 @@ void TextResource::init()
 
     //=====================================================================================================================================
     //ES
-    Lan = ES;
+    Lan = es;
     nTextSize = 30;
     currentFont = instance.fontSuit;
 
@@ -6563,9 +6563,9 @@ void TextResource::init()
     fontData[Lan][PAGE_RESPONSE].insert("labelPageNum",QFont(currentFont,instance.pixelToPoint(28)));
 
 #if FONT_DEBUG
-    for(const auto& textName : fontData[KR][PAGE_PASSWORD].keys())
+    for(const auto& textName : fontData[ko][PAGE_PASSWORD].keys())
     {
-        QFont font = fontData[KR][PAGE_PASSWORD][textName];
+        QFont font = fontData[ko][PAGE_PASSWORD][textName];
         qDebug() <<"TextName: "<< textName << "->" << QFontInfo(font).family();
     }
 #endif

--- a/textresource.cpp
+++ b/textresource.cpp
@@ -31,8 +31,8 @@ void TextResource::init()
                                          "한국어",
                                          "ENGLISH",
                                          "日本語",
-                                         "繁體中文",
                                          "简体中文",
+                                         "繁體中文",
                                          "ESPAÑOL"
                                      });
 
@@ -76,8 +76,8 @@ void TextResource::init()
                                             "한국어",
                                             "ENGLISH",
                                             "日本語",
-                                            "繁體中文",
                                             "简体中文",
+                                            "繁體中文",
                                             "ESPAÑOL"
                                         });
 
@@ -1094,8 +1094,8 @@ void TextResource::init()
                                          "한국어",
                                          "ENGLISH",
                                          "日本語",
-                                         "繁體中文",
                                          "简体中文",
+                                         "繁體中文",
                                          "ESPAÑOL"
                                      });
 
@@ -1138,8 +1138,8 @@ void TextResource::init()
                                             "한국어",
                                             "ENGLISH",
                                             "日本語",
-                                            "繁體中文",
                                             "简体中文",
+                                            "繁體中文",
                                             "ESPAÑOL"
                                         });
 
@@ -2166,8 +2166,8 @@ void TextResource::init()
                                          "한국어",
                                          "ENGLISH",
                                          "日本語",
-                                         "繁體中文",
                                          "简体中文",
+                                         "繁體中文",
                                          "ESPAÑOL"
                                      });
     //CUSTOM_BUTTON
@@ -2209,8 +2209,8 @@ void TextResource::init()
                                             "한국어",
                                             "ENGLISH",
                                             "日本語",
-                                            "繁體中文",
                                             "简体中文",
+                                            "繁體中文",
                                             "ESPAÑOL"
                                         });
 
@@ -3267,8 +3267,8 @@ void TextResource::init()
                                          "한국어",
                                          "ENGLISH",
                                          "日本語",
-                                         "繁體中文",
                                          "简体中文",
+                                         "繁體中文",
                                          "ESPAÑOL"
                                      });
 
@@ -3311,8 +3311,8 @@ void TextResource::init()
                                             "한국어",
                                             "ENGLISH",
                                             "日本語",
-                                            "繁體中文",
                                             "简体中文",
+                                            "繁體中文",
                                             "ESPAÑOL"
                                         });
 
@@ -4367,8 +4367,8 @@ void TextResource::init()
                                          "한국어",
                                          "ENGLISH",
                                          "日本語",
-                                         "繁體中文",
                                          "简体中文",
+                                         "繁體中文",
                                          "ESPAÑOL"
                                      });
 
@@ -4411,8 +4411,8 @@ void TextResource::init()
                                             "한국어",
                                             "ENGLISH",
                                             "日本語",
-                                            "繁體中文",
                                             "简体中文",
+                                            "繁體中文",
                                             "ESPAÑOL"
                                         });
 
@@ -5465,8 +5465,8 @@ void TextResource::init()
                                          "한국어",
                                          "ENGLISH",
                                          "日本語",
-                                         "繁體中文",
                                          "简体中文",
+                                         "繁體中文",
                                          "ESPAÑOL"
                                      });
     //CUSTOM_BUTTON
@@ -5508,8 +5508,8 @@ void TextResource::init()
                                             "한국어",
                                             "ENGLISH",
                                             "日本語",
-                                            "繁體中文",
                                             "简体中文",
+                                            "繁體中文",
                                             "ESPAÑOL"
                                         });
 


### PR DESCRIPTION
## Summary
- DeviceLanguage enum을 BCP 47 표준 코드로 교체 (KR→ko, EN→en, JP→ja, SC→zh_CN, TC→zh_TW, ES→es)
- 언어 선택 UI 간체/번체 표시 텍스트 순서 교정
- 배터리 아이콘 구간 80/50/25/10으로 변경
- 히스토리 결과 페이지 상단 컴포넌트 숨김 처리 (시계만 유지)

## 변경 파일 (13개)
- `singleton.h` / `singleton.cpp` — enum 정의 및 참조 교체
- `textresource.cpp` — 언어 섹션 변수 + 간체/번체 표시 순서 교정
- `Page/pageselect.cpp`, `pageresult.cpp`, `pagethreshold.cpp`, `pagetrans.cpp`, `pagetrans.h` — enum 참조 교체
- `Component/componentbattery.cpp` — 배터리 구간 변경
- `Component/componenthome.cpp`, `componentmenu.cpp`, `componentbluetooth.cpp` — 히스토리 결과 클릭 차단 코드 제거
- `mainwindow.cpp` — 히스토리 결과 페이지 컴포넌트 숨김 + 시계 예외 처리

## Test plan
- [x] PC 빌드 (DEVICE false) 성공 확인
- [x] enum 정수값 호환성 확인 (ko=0, en=1, ja=2, zh_CN=3, zh_TW=4, es=5)
- [x] 히스토리 결과 페이지 상단 컴포넌트 숨김 + 시계 표시 확인
- [x] 다른 페이지 컴포넌트 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)