### PR TITLE
feat: 업그레이드 컨펌 페이지 확인→재부팅 버튼 교체

### DIFF
--- a/BloodGlucoseMeterPortable_RE1.pro
+++ b/BloodGlucoseMeterPortable_RE1.pro
@@ -29,6 +29,7 @@ SOURCES += \
     Button/custombuttonmeasurestart.cpp \
     Button/custombuttonno.cpp \
     Button/custombuttonok.cpp \
+    Button/custombuttonreboot.cpp \
     Button/custombuttonsave.cpp \
     Button/custombuttonupgrade.cpp \
     Button/custombuttonyes.cpp \
@@ -133,6 +134,7 @@ HEADERS += \
     Button/custombuttonmeasurestart.h \
     Button/custombuttonno.h \
     Button/custombuttonok.h \
+    Button/custombuttonreboot.h \
     Button/custombuttonsave.h \
     Button/custombuttonupgrade.h \
     Button/custombuttonyes.h \

--- a/Button/custombuttonreboot.cpp
+++ b/Button/custombuttonreboot.cpp
@@ -1,0 +1,24 @@
+#include "custombuttonreboot.h"
+
+CustomButtonReboot::CustomButtonReboot(QWidget *parent) : CustomButton(parent)
+{
+    this->setGeometry(320,390,320,90);
+    init();
+}
+
+void CustomButtonReboot::init()
+{
+    labelButtonReboot = new QLabel(this);
+    labelButtonReboot->setGeometry(0,0,this->width(),this->height());
+    labelButtonReboot->setAlignment(Qt::AlignCenter);
+
+    update();
+}
+
+void CustomButtonReboot::update()
+{
+    labelButtonReboot->setFont(textResource.getFont(CUSTOM_BUTTON,"labelButtonReboot"));
+    labelButtonReboot->setText(textResource.getText(CUSTOM_BUTTON,"labelButtonReboot").at(0));
+
+    labelButtonReboot->setStyleSheet("background-color: #077bdd; color: #ffffff;");
+}

--- a/Button/custombuttonreboot.h
+++ b/Button/custombuttonreboot.h
@@ -1,0 +1,19 @@
+#ifndef CUSTOMBUTTONREBOOT_H
+#define CUSTOMBUTTONREBOOT_H
+
+#include "custombutton.h"
+
+class CustomButtonReboot : public CustomButton
+{
+    Q_OBJECT
+public:
+    CustomButtonReboot(QWidget *parent);
+    QLabel *labelButtonReboot;
+
+    void update() override;
+
+private:
+    void init();
+};
+
+#endif // CUSTOMBUTTONREBOOT_H

--- a/Page/page.h
+++ b/Page/page.h
@@ -12,6 +12,7 @@
 #include "Button/custombuttonmeasurere.h"
 #include "Button/custombuttonsave.h"
 #include "Button/custombuttonupgrade.h"
+#include "Button/custombuttonreboot.h"
 #include "Button/custombuttonyes.h"
 #include "Button/custombuttonno.h"
 #include "Button/custombuttonlanguage.h"

--- a/Page/pageupgradeconfirm.cpp
+++ b/Page/pageupgradeconfirm.cpp
@@ -11,7 +11,7 @@ void PageUpgradeConfirm::init()
     labelText = new QLabel(this);
     labelText->setGeometry(50,100,540,280);
     labelText->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
-    customButtonOK = new CustomButtonOK(this);
+    customButtonReboot = new CustomButtonReboot(this);
     customButtonCancel = new CustomButtonCancel(this);
 
     update();
@@ -19,7 +19,7 @@ void PageUpgradeConfirm::init()
 
 void PageUpgradeConfirm::update()
 {
-    customButtonOK->update();
+    customButtonReboot->update();
     customButtonCancel->update();
 
     labelText->setFont(textResource.getFont(PAGE_UPGRADE_CONFIRM,"labelText"));
@@ -41,7 +41,7 @@ void PageUpgradeConfirm::pageHide()
 
 void PageUpgradeConfirm::mousePressEvent(QMouseEvent *ev)
 {
-    if(instance.touchCheck(customButtonOK->geometry(),ev))
+    if(instance.touchCheck(customButtonReboot->geometry(),ev))
     {
 #if DEVICE
         instance.guiApi.glucoseSetUpgradeStorage(GAPI_ACT_STOP);

--- a/Page/pageupgradeconfirm.h
+++ b/Page/pageupgradeconfirm.h
@@ -13,7 +13,7 @@ public:
     QString strDirPath = "/ImageUpgradeConfirm";
 
     QLabel *labelText;
-    CustomButtonOK *customButtonOK;
+    CustomButtonReboot *customButtonReboot;
     CustomButtonCancel *customButtonCancel;
 
     void update() override;

--- a/textresource.cpp
+++ b/textresource.cpp
@@ -65,6 +65,9 @@ void TextResource::init()
     fontData[Lan][CUSTOM_BUTTON].insert("labelButtonUpgrade",QFont(currentFont,instance.pixelToPoint(30),QFont::Bold));
     textData[Lan][CUSTOM_BUTTON].insert("labelButtonUpgrade",QStringList{"소프트웨어 업그레이드"});
 
+    fontData[Lan][CUSTOM_BUTTON].insert("labelButtonReboot",QFont(currentFont,instance.pixelToPoint(30),QFont::Bold));
+    textData[Lan][CUSTOM_BUTTON].insert("labelButtonReboot",QStringList{"재부팅"});
+
     fontData[Lan][CUSTOM_BUTTON].insert("labelButtonYes",QFont(currentFont,instance.pixelToPoint(30),QFont::Bold));
     textData[Lan][CUSTOM_BUTTON].insert("labelButtonYes",QStringList{"네"});
 
@@ -1126,6 +1129,9 @@ void TextResource::init()
 
     fontData[Lan][CUSTOM_BUTTON].insert("labelButtonUpgrade",QFont(currentFont,instance.pixelToPoint(30),QFont::Bold));
     textData[Lan][CUSTOM_BUTTON].insert("labelButtonUpgrade",QStringList{"Software Upgrade"});
+
+    fontData[Lan][CUSTOM_BUTTON].insert("labelButtonReboot",QFont(currentFont,instance.pixelToPoint(30),QFont::Bold));
+    textData[Lan][CUSTOM_BUTTON].insert("labelButtonReboot",QStringList{"Reboot"});
 
     fontData[Lan][CUSTOM_BUTTON].insert("labelButtonYes",QFont(currentFont,instance.pixelToPoint(30),QFont::Bold));
     textData[Lan][CUSTOM_BUTTON].insert("labelButtonYes",QStringList{"Yes"});
@@ -2197,6 +2203,9 @@ void TextResource::init()
 
     fontData[Lan][CUSTOM_BUTTON].insert("labelButtonUpgrade", QFont(currentFont, instance.pixelToPoint(30), QFont::Bold));
     textData[Lan][CUSTOM_BUTTON].insert("labelButtonUpgrade", QStringList{"ソフトウェア更新"});
+
+    fontData[Lan][CUSTOM_BUTTON].insert("labelButtonReboot",QFont(currentFont,instance.pixelToPoint(30),QFont::Bold));
+    textData[Lan][CUSTOM_BUTTON].insert("labelButtonReboot",QStringList{"再起動"});
 
     fontData[Lan][CUSTOM_BUTTON].insert("labelButtonYes",QFont(currentFont,instance.pixelToPoint(30),QFont::Bold));
     textData[Lan][CUSTOM_BUTTON].insert("labelButtonYes",QStringList{"はい"});
@@ -3300,6 +3309,9 @@ void TextResource::init()
     fontData[Lan][CUSTOM_BUTTON].insert("labelButtonUpgrade", QFont(currentFont, instance.pixelToPoint(30), QFont::Bold));
     textData[Lan][CUSTOM_BUTTON].insert("labelButtonUpgrade", QStringList{"软件升级"}); // Software Upgrade
 
+    fontData[Lan][CUSTOM_BUTTON].insert("labelButtonReboot",QFont(currentFont,instance.pixelToPoint(30),QFont::Bold));
+    textData[Lan][CUSTOM_BUTTON].insert("labelButtonReboot",QStringList{"重启"});
+
     fontData[Lan][CUSTOM_BUTTON].insert("labelButtonYes",QFont(currentFont,instance.pixelToPoint(30),QFont::Bold));
     textData[Lan][CUSTOM_BUTTON].insert("labelButtonYes",QStringList{"是"});
 
@@ -4400,6 +4412,9 @@ void TextResource::init()
     fontData[Lan][CUSTOM_BUTTON].insert("labelButtonUpgrade", QFont(currentFont, instance.pixelToPoint(30), QFont::Bold));
     textData[Lan][CUSTOM_BUTTON].insert("labelButtonUpgrade", QStringList{"軟體升級"}); // Software Upgrade
 
+    fontData[Lan][CUSTOM_BUTTON].insert("labelButtonReboot",QFont(currentFont,instance.pixelToPoint(30),QFont::Bold));
+    textData[Lan][CUSTOM_BUTTON].insert("labelButtonReboot",QStringList{"重新啟動"});
+
     fontData[Lan][CUSTOM_BUTTON].insert("labelButtonYes",QFont(currentFont,instance.pixelToPoint(30),QFont::Bold));
     textData[Lan][CUSTOM_BUTTON].insert("labelButtonYes",QStringList{"是"});
 
@@ -5496,6 +5511,9 @@ void TextResource::init()
 
     fontData[Lan][CUSTOM_BUTTON].insert("labelButtonUpgrade", QFont(currentFont, instance.pixelToPoint(30), QFont::Bold));
     textData[Lan][CUSTOM_BUTTON].insert("labelButtonUpgrade", QStringList{"Actualizar software"}); // Software Upgrade
+
+    fontData[Lan][CUSTOM_BUTTON].insert("labelButtonReboot",QFont(currentFont,instance.pixelToPoint(30),QFont::Bold));
+    textData[Lan][CUSTOM_BUTTON].insert("labelButtonReboot",QStringList{"Reiniciar"});
 
     fontData[Lan][CUSTOM_BUTTON].insert("labelButtonYes",QFont(currentFont,instance.pixelToPoint(30),QFont::Bold));
     textData[Lan][CUSTOM_BUTTON].insert("labelButtonYes",QStringList{"Sí"});


### PR DESCRIPTION
## Summary
- CustomButtonReboot 컴포넌트 신규 생성
- PageUpgradeConfirm에서 CustomButtonOK → CustomButtonReboot 교체
- 6개 언어 번역 추가 (재부팅/Reboot/再起動/重启/重新啟動/Reiniciar)

## 변경 파일
- `Button/custombuttonreboot.h`, `Button/custombuttonreboot.cpp` (신규)
- `Page/pageupgradeconfirm.h`, `Page/pageupgradeconfirm.cpp`
- `Page/page.h`
- `textresource.cpp`
- `BloodGlucoseMeterPortable_RE1.pro`

## Test plan
- [x] 빌드 성공 확인
- [x] 업그레이드 컨펌 페이지 "재부팅" 버튼 표시 확인
- [x] 다른 페이지 "확인" 버튼 영향 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)