### PR TITLE
feat: 팬텀 테스트 모드 GuiApi 연동 및 캘리브레이션 갱신

### DIFF
--- a/Page/pagedebugphantom.cpp
+++ b/Page/pagedebugphantom.cpp
@@ -73,6 +73,7 @@ void PageDebugPhantom::mousePressEvent(QMouseEvent *ev)
         instance.bIsPhantomTest = bPhantomState;
 #if DEVICE
         instance.guiApi.glucoseSetPhantomUsage(bPhantomState ? GAPI_ACT_START : GAPI_ACT_STOP);
+        instance.getCaliGainCompleteCheck();
 #endif
         pageHide();
     }

--- a/Page/pagedebugphantom.cpp
+++ b/Page/pagedebugphantom.cpp
@@ -72,7 +72,7 @@ void PageDebugPhantom::mousePressEvent(QMouseEvent *ev)
     {
         instance.bIsPhantomTest = bPhantomState;
 #if DEVICE
-        // TODO: phantom API
+        instance.guiApi.glucoseSetPhantomUsage(bPhantomState ? GAPI_ACT_START : GAPI_ACT_STOP);
 #endif
         pageHide();
     }

--- a/guiapi/gapi.h
+++ b/guiapi/gapi.h
@@ -256,8 +256,8 @@ typedef struct gapiPressureValue_T {
 #define GAPI_MOTOR_MAX_DEPTH					4095
 #define GAPI_MOTOR_MAX_SPEED					100			// 0~100
 
-#define GAPI_MOTOR_DFT_DEPTH					700		// IKSONG 250902: 4000 -> 700
-#define GAPI_MOTOR_DFT_SPEED					30		// IKSONG 250902: 40 -> 30
+#define GAPI_MOTOR_DFT_DEPTH					700		// IKSONG 250902: 4000->700
+#define GAPI_MOTOR_DFT_SPEED					20		// IKSONG 250902: 40->30: 260424: 30->20
 
 typedef struct gapiMotorData_T {
 	unsigned short depth;
@@ -503,10 +503,10 @@ typedef struct gapiMeasureGetRaw_T {
 	unsigned int temp_valid;
 	unsigned short temp_obj[GAPI_TEMP_CH_MAX];
 	unsigned short temp_amb[GAPI_TEMP_CH_MAX];
-	unsigned short raw_cnt[GAPI_ADC_CH_MAX];
-	unsigned short raw_val[GAPI_ADC_CH_MAX][GAPI_MEASURE_ADC_RAW_MAX];
-	unsigned short pres_cnt[GAPI_PRESSURE_CH_MAX];
-	short pres_val[GAPI_PRESSURE_CH_MAX][GAPI_MEASURE_PRESSURE_RAW_MAX];
+	unsigned short raw_cnt;
+	unsigned short raw_val[GAPI_MEASURE_ADC_RAW_MAX];
+	unsigned short pres_cnt;
+	short pres_val[GAPI_MEASURE_PRESSURE_RAW_MAX];
 } __attribute__((__packed__)) gapiMeasureGetRaw_t;
 
 /*---------------------------------------------------------------------------*
@@ -557,126 +557,32 @@ typedef struct gapiHwTestMeasureAct_T {
  *---------------------------------------------------------------------------*/
 typedef enum {
 	GAPI_CALITEST_OPMODE_RAW_TEST = 0,
-	GAPI_CALITEST_OPMODE_SINGLE_ADJUST,
-	GAPI_CALITEST_OPMODE_AMP_TEST_POTENTIOMETER,
-	GAPI_CALITEST_OPMODE_AMP_TEST_LED,
-	GAPI_CALITEST_OPMODE_AMP_NORMAL,
-	GAPI_CALITEST_OPMODE_INVITRO_TEST,
-	GAPI_CALITEST_OPMODE_REPEAT_TEST,
-	GAPI_CALITEST_OPMODE_MEASURE_TEST,
+	GAPI_CALITEST_OPMODE_LED_PWM,
 	GAPI_CALITEST_OPMODE_MAX
 } gapiCaliTestOpmode_e;
 
-typedef enum {
-	GAPI_CALITEST_LED_1 = 0,
-	GAPI_CALITEST_LED_2,
-	GAPI_CALITEST_LED_BOTH,
-	GAPI_CALITEST_LED_MAX
-} gapiCaliTestLed_e;
-
 // raw test
 typedef struct gapiCaliTestRaw_T {
-	unsigned char led;
-	unsigned char bright;
-	unsigned short start;
-	unsigned short end;
-	unsigned char revd[2];
+	unsigned short regi;
+	unsigned short bright;
+	unsigned short duration;
+	unsigned short revd;
 } __attribute__((__packed__)) gapiCaliTestRaw_t;
 
-// single LED adjust
-typedef enum {
-	GAPI_CALITEST_SA_LED_STEP1 = 0,
-	GAPI_CALITEST_SA_LED_STEP2,
-	GAPI_CALITEST_SA_LED_MAX_STEP
-} gapiCaliTestSaLedStep_e;
-
-typedef struct gapiCaliTestSingleAdjust_T {
-	unsigned char led_num;
-	unsigned char bright[GAPI_CALITEST_SA_LED_MAX_STEP];
-	unsigned char duration;
+// LWD PWM test
+typedef struct gapiCaliTestLedPwm_T {
+	unsigned short regi;
+	unsigned short bright1;
+	unsigned short bright2;
+	unsigned short duty;
 	unsigned short period;
-	unsigned char revd[2];
-} __attribute__((__packed__)) gapiCaliTestSingleAdjust_t;
-
-typedef struct gapiCaliTestAmpTest_T {
-	unsigned char num;
-	unsigned short start_idx;
-	unsigned short stop_idx;
-	unsigned char step;
-	unsigned char regi_ch;
-	unsigned char revd;
-} __attribute__((__packed__)) gapiCaliTestAmpTest_t;
-
-typedef struct gapiCaliTestAmpNormal_T {
-	unsigned char num;
-	unsigned short period;
-	unsigned char led_step;
-	unsigned char regi_step;
-	unsigned char revd[3];
-} __attribute__((__packed__)) gapiCaliTestAmpNormal_t;
-
-typedef struct gapiCaliTestPressureOpt_T {
-	unsigned char used[GAPI_PRESSURE_CH_MAX];
-	unsigned char revd[2];
-} __attribute__((__packed__)) gapiCaliTestPressureOpt_t;
-
-// in-vitro test
-typedef enum {
-	GAPI_CALITEST_INVITRO_BRIGHT_START = 0,
-	GAPI_CALITEST_INVITRO_BRIGHT_20 = GAPI_CALITEST_INVITRO_BRIGHT_START,
-	GAPI_CALITEST_INVITRO_BRIGHT_40,
-	GAPI_CALITEST_INVITRO_BRIGHT_60,
-	GAPI_CALITEST_INVITRO_BRIGHT_80,
-	GAPI_CALITEST_INVITRO_BRIGHT_100,
-	GAPI_CALITEST_INVITRO_BRIGHT_MAX
-} gapiCaliTestInVitroBright_e;
-
-typedef enum {
-	GAPI_CALITEST_INVITRO_MODE_NORMAL = 0,
-	GAPI_CALITEST_INVITRO_MODE_ADJUST,
-	GAPI_CALITEST_INVITRO_MODE_MAX
-} gapiCaliTestInVitroMode_e;
-
-typedef struct gapiCaliTestInVitro_T {
-	unsigned char mode;
-	unsigned char led;
-	unsigned short act;
-	unsigned short idle;
-	unsigned short loop;
-} __attribute__((__packed__)) gapiCaliTestInVitro_t;
-
-// measure test
-typedef struct gapiCaliTestMeasure_T {
-	unsigned char led;
-	unsigned char bright;
-	unsigned short start;
-	unsigned short end;
-	unsigned char save;
-	unsigned char len;
-	double cof1;
-	double cof2;
-} __attribute__((__packed__)) gapiCaliTestMeasure_t;
-
-// repeat test
-typedef struct gapiCaliTestRepeat_T {
-	unsigned char led;
-	unsigned char bright;
-	unsigned short act;
-	unsigned short idle;
-	unsigned short loop;
-} __attribute__((__packed__)) gapiCaliTestRepeat_t;
+	unsigned short duration;
+} __attribute__((__packed__)) gapiCaliTestLedPwm_t;
 
 // calibration data
 typedef struct gapiCaliTestData_T {
 	gapiCaliTestRaw_t raw;
-	gapiCaliTestSingleAdjust_t sa_led;
-	gapiCaliTestAmpTest_t amp_regi;
-	gapiCaliTestAmpTest_t amp_led;
-	gapiCaliTestAmpNormal_t amp_norm;
-	gapiCaliTestPressureOpt_t pres_opt;
-	gapiCaliTestInVitro_t invitro;
-	gapiCaliTestMeasure_t measure;
-	gapiCaliTestRepeat_t repeat;
+	gapiCaliTestLedPwm_t led_pwm;
 } __attribute__((__packed__)) gapiCaliTestData_t;
 
 // measurement activity

--- a/guiapi/guiapi.cpp
+++ b/guiapi/guiapi.cpp
@@ -2600,6 +2600,45 @@ int GuiApi::glucoseMonGetRawData (gapiSysProcMonInfo_t *rMonP)
  * PARAMETERS : 
  * RETURNS : None
  *****************************************************************************/
+int GuiApi::glucoseSetPhantomUsage (int usage)
+{
+	if (vtIpcProcess ((uint8_t) VTIPC_MSGID_PHANTOM_USAGE, (uint8_t) VTIPC_MSGACT_SET, \
+		(void *)&usage, sizeof (int)) != GAPI_SUCCESS)
+	{
+		gapiError("couldn't set phantom usage.\n");
+		return GAPI_FAIL;
+	}
+
+	return GAPI_SUCCESS;
+}
+
+/*****************************************************************************
+ * FUNCTION NAME : 
+ * DESCRIPTIONS : 
+ * PARAMETERS : 
+ * RETURNS : None
+ *****************************************************************************/
+int GuiApi::glucoseGetPhantomUsage (int *rUsageP)
+{
+	if (!rUsageP)
+		return GAPI_FAIL;
+
+	if (vtIpcProcess ((uint8_t) VTIPC_MSGID_PHANTOM_USAGE, (uint8_t) VTIPC_MSGACT_GET, \
+		(void *)rUsageP, sizeof (int)) != GAPI_SUCCESS)
+	{
+		gapiError("couldn't get phantom usage.\n");
+		return GAPI_FAIL;
+	}
+
+	return GAPI_SUCCESS;
+}
+
+/*****************************************************************************
+ * FUNCTION NAME : 
+ * DESCRIPTIONS : 
+ * PARAMETERS : 
+ * RETURNS : None
+ *****************************************************************************/
 int GuiApi::glucoseAttach (void)
 {
 	FILE *fp;

--- a/guiapi/guiapi.h
+++ b/guiapi/guiapi.h
@@ -232,6 +232,8 @@ class GuiApi {
 		int glucoseGetMotorData (gapiMotorData_t *rMotorP);
 		int glucoseSetGainDetTime (uint32_t time);
 		int glucoseGetGainDetTime (uint32_t *rTimeP);
+		int glucoseSetPhantomUsage (int usage);			// GAPI_ACT_START or GAPI_ACT_STOP
+		int glucoseGetPhantomUsage (int *rUsageP);	// GAPI_ACT_START or GAPI_ACT_STOP
 
 		int glucoseSysProcAct (gapiSysProcAct_t *actP);
 		int glucoseMonGetRawData (gapiSysProcMonInfo_t *rMonP);

--- a/guiapi/vtipc.h
+++ b/guiapi/vtipc.h
@@ -93,6 +93,9 @@ typedef enum {
 	// glucose high & low value
 	VTIPC_MSGID_GLUCOSE_HIGHLOW,
 
+	// phantom usage
+	VTIPC_MSGID_PHANTOM_USAGE,
+
 	VTIPC_MSGID_MAX
 } vtIpcMsgId_e;
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -14,6 +14,10 @@ MainWindow::MainWindow(QWidget* parent)
     int nUser = USER_MAX;
     instance.guiApi.glucoseGetActUser(&nUser);
 
+    int nPhantomUsage = GAPI_ACT_STOP;
+    if(instance.guiApi.glucoseGetPhantomUsage(&nPhantomUsage) == GAPI_SUCCESS)
+        instance.bIsPhantomTest = (nPhantomUsage == GAPI_ACT_START);
+
     if(nUser != USER_MAX)
     {
         qDebug()<<"userCheck";

--- a/textresource.cpp
+++ b/textresource.cpp
@@ -1081,6 +1081,12 @@ void TextResource::init()
     //                                              "개발팀 확인 중",
     //                                          });
 
+    //PAGE_RESPONSE
+    fontData[Lan][PAGE_RESPONSE].insert("labelText",QFont(currentFont,instance.pixelToPoint(36),QFont::Bold));
+    fontData[Lan][PAGE_RESPONSE].insert("labelNumCurrent",QFont(currentFont,instance.pixelToPoint(28)));
+    fontData[Lan][PAGE_RESPONSE].insert("labelNumAll",QFont(currentFont,instance.pixelToPoint(28),QFont::Bold));
+    fontData[Lan][PAGE_RESPONSE].insert("labelPageNum",QFont(currentFont,instance.pixelToPoint(28)));
+
     //====================================================================================================================================
     //EN
     Lan = en;


### PR DESCRIPTION
## Summary
- 기기 시작 시 `glucoseGetPhantomUsage()`로 팬텀 상태 조회하여 상단바 색상 반영
- 디버그 팬텀 페이지 SAVE 시 `glucoseSetPhantomUsage()`로 하드웨어에 상태 저장
- SET 직후 `getCaliGainCompleteCheck()`로 캘리브레이션 데이터 즉시 갱신
- guiapi 업데이트 (팬텀 API, 모터 속도, raw 데이터 구조체, 캘리 테스트 모드 축소)
- 한국어 PAGE_RESPONSE fontData 누락 수정

## 변경 파일
- `mainwindow.cpp` — 시작 시 팬텀 상태 조회
- `Page/pagedebugphantom.cpp` — SET API 호출 + 캘리 갱신
- `textresource.cpp` — 한국어 PAGE_RESPONSE fontData 추가
- `guiapi/*` — API 업데이트

## Test plan
- [x] PC 빌드 정상 확인
- [ ] 실기기에서 팬텀 ON/OFF 토글 후 상단바 색상 변경 확인
- [ ] 팬텀 ON 상태에서 바로 측정 진입 가능 여부 확인
- [ ] 기기 재시작 후 팬텀 상태 유지 확인
- [ ] PAGE_RESPONSE 폰트 에러 메시지 해소 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)